### PR TITLE
chore: mark barocss-docs package as private

### DIFF
--- a/apps/barocss-docs/package.json
+++ b/apps/barocss-docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "barocss-docs",
   "version": "1.0.0",
+  "private": true,
   "description": "Documentation for BaroCSS - Revolutionary real-time CSS library",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- Added "private": true to package.json to prevent accidental publishing of the documentation package.

## 📝 Description
Brief description of what this PR does.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature  
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring

## ✅ Checklist
- [ ] Tests pass (`pnpm test`)
- [ ] Build works (`pnpm build`)
- [ ] Changeset added (if needed)

## 🔗 Related Issues
Closes #[issue_number]

## 📸 Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

---
**Ready for review!** 🚀